### PR TITLE
Add `level` and `throw` options to `MLJTest.test`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJTest"
 uuid = "697918b4-fdc1-4f9e-8ff9-929724cee270"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 MLJ = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"

--- a/README.md
+++ b/README.md
@@ -23,4 +23,46 @@ using the specified training `data`:
 MLJTest.test(models, data...; verbosity=1, mod=Main, loading_only=false) -> failures, summary
 ```
 
-See the method document string for details. 
+For detailed documentation, run `using MLJTest; @doc MLJTest.test`.
+
+
+# Examples
+
+## Testing models in a new MLJ model interface implementation
+
+The following tests the model interface implemented by some model type
+`MyClassifier`, as might appear in tests for a package providing that
+type:
+
+```
+import MLJTest
+using Test
+X, y = MLJTest.MLJ.make_blobs()
+failures, summary = MLJTest.test([MyClassifier, ], X, y, verbosity=1, mod=@__MODULE__)
+@test isempty(failures)
+```
+
+## Testing models after filtering models in the registry
+
+The following applies comprehensive integration tests to all
+regressors provided by the package GLM.jl appearing in the MLJ Model
+Registry. Since GLM.jl models are provided through the interface
+package `MLJGLMInterface`, this must be in the current environment:
+
+```
+Pkg.add("MLJGLMInterface")
+import MLJBase, MLJTest
+using DataFrames # to view summary
+X, y = MLJTest.MLJ.make_regression();
+regressors = MLJTest.MLJ.models(matching(X, y)) do m
+    m.package_name == "GLM"
+end
+failures, summary = MLJTest.test(
+    regressors, 
+    X, 
+    y, 
+    verbosity=1, 
+    mod=@__MODULE__,
+    level=3)
+summary |> DataFrame
+```

--- a/src/attemptors.jl
+++ b/src/attemptors.jl
@@ -1,5 +1,3 @@
-str(model_metadata) = "$(model_metadata.name) from $(model_metadata.package_name)"
-
 """
     attempt(f, message="")
 
@@ -11,7 +9,7 @@ If `message` is not empty, then it is logged to `Info`, together with
 the second return value ("✓" or "×").
 
 """
-function attempt(f, message="")
+function attempt(f, message)
     ret = try
         (f(), "✓")
     catch ex

--- a/src/attemptors.jl
+++ b/src/attemptors.jl
@@ -1,18 +1,20 @@
 """
-    attempt(f, message)
+    attempt(f, message; throw=false)
 
 Return `(f(), "✓") if `f()` executes without throwing an
 exception. Otherwise, return `(ex, "×"), where `ex` is the exception
-thrown.
+caught. Only truly throw the exception if `throw=true`. 
 
 If `message` is not empty, then it is logged to `Info`, together with
 the second return value ("✓" or "×").
 
+
 """
-function attempt(f, message)
+function attempt(f, message; throw=false)
     ret = try
         (f(), "✓")
     catch ex
+        throw && Base.throw(ex)
         (ex, "×")
     end
     isempty(message) || @info message*last(ret)
@@ -37,10 +39,10 @@ end
 
 root(load_path) = split(load_path, '.') |> first
 
-function model_type(proxy, mod; verbosity=1)
+function model_type(proxy, mod; throw=false, verbosity=1)
     # check interface package really is in current environment:
     message = "`[:model_type]` Loading model type "
-    model_type, outcome = attempt(finalize(message, verbosity)) do
+    model_type, outcome = attempt(finalize(message, verbosity); throw) do
         load_path = MLJTest.load_path(proxy) # MLJ.load_path(proxy) *****
         load_path_ex = load_path |> Meta.parse
         api_pkg_ex = root(load_path) |> Symbol
@@ -67,31 +69,31 @@ function model_type(proxy, mod; verbosity=1)
         if !isnothing(api_pkg) &&
                api_pkg != "unknown" &&
                contains(model_type.msg, "$api_pkg not found in")
-            throw(model_type)
+            Base.throw(model_type)
         end
     end
 
     return model_type, outcome
 end
 
-function model_instance(model_type; verbosity=1)
+function model_instance(model_type; throw=false, verbosity=1)
     message = "`[:model_instance]` Instantiating default model "
-    attempt(finalize(message, verbosity))  do
+    attempt(finalize(message, verbosity); throw)  do
         model_type()
     end
 end
 
-function fitted_machine(model, data...; verbosity=1)
+function fitted_machine(model, data...; throw=false, verbosity=1)
     message = "`[:fitted_machine]` Fitting machine "
-    attempt(finalize(message, verbosity))  do
+    attempt(finalize(message, verbosity); throw)  do
         mach = machine(model, data...)
         fit!(mach, verbosity=-1)
     end
 end
 
-function operations(fitted_machine, data...; verbosity=1)
+function operations(fitted_machine, data...; throw=false, verbosity=1)
     message = "`[:operations]` Calling `predict`, `transform` and/or `inverse_transform` "
-    attempt(finalize(message, verbosity))  do
+    attempt(finalize(message, verbosity); throw)  do
         operations = String[]
         methods = MLJ.implemented_methods(fitted_machine.model)
         if :predict in methods
@@ -110,10 +112,10 @@ function operations(fitted_machine, data...; verbosity=1)
     end
 end
 
-function threshold_prediction(model, data...; verbosity=1)
+function threshold_prediction(model, data...; throw=false, verbosity=1)
     message = "`[:threshold_predictor]` Calling fit!/predict for threshold predictor "*
         "test) "
-    attempt(finalize(message, verbosity)) do
+    attempt(finalize(message, verbosity); throw) do
         tmodel = BinaryThresholdPredictor(model)
         mach = machine(tmodel, data...)
         fit!(mach, verbosity=0)
@@ -121,9 +123,9 @@ function threshold_prediction(model, data...; verbosity=1)
     end
 end
 
-function evaluation(measure, model, data...; verbosity=1)
+function evaluation(measure, model, data...; throw=false, verbosity=1)
     message = "`[:evaluation]` Evaluating performance "
-    attempt(finalize(message, verbosity)) do
+    attempt(finalize(message, verbosity); throw) do
         evaluate(model, data...;
                  measure=measure,
                  resampling=Holdout(),
@@ -131,9 +133,9 @@ function evaluation(measure, model, data...; verbosity=1)
     end
 end
 
-function tuned_pipe_evaluation(measure, model, data...; verbosity=1)
+function tuned_pipe_evaluation(measure, model, data...; throw=false, verbosity=1)
     message = "`[:tuned_pipe_evaluation]` Evaluating perfomance in a tuned pipeline "
-    attempt(finalize(message, verbosity)) do
+    attempt(finalize(message, verbosity); throw) do
         pipe = identity |> model
         tuned_pipe = TunedModel(models=[pipe,],
                                 measure=measure)
@@ -143,8 +145,8 @@ function tuned_pipe_evaluation(measure, model, data...; verbosity=1)
     end
 end
 
-function ensemble_prediction(model, data...; verbosity=1)
-    attempt(finalize("`[:ensemble_prediction]` Ensembling ", verbosity)) do
+function ensemble_prediction(model, data...; throw=false, verbosity=1)
+    attempt(finalize("`[:ensemble_prediction]` Ensembling ", verbosity); throw) do
         imodel = EnsembleModel(model=model,
                                n=2)
         mach = machine(imodel, data...)
@@ -153,9 +155,9 @@ function ensemble_prediction(model, data...; verbosity=1)
     end
 end
 
-function iteration_prediction(measure, model, data...; verbosity=1)
+function iteration_prediction(measure, model, data...; throw=false, verbosity=1)
     message =  "`[:iteration_prediction]` Iterating with controls "
-    attempt(finalize(message, verbosity)) do
+    attempt(finalize(message, verbosity); throw) do
         imodel = IteratedModel(model=model,
                                measure=measure,
                                controls=[Step(1),

--- a/src/attemptors.jl
+++ b/src/attemptors.jl
@@ -1,5 +1,5 @@
 """
-    attempt(f, message="")
+    attempt(f, message)
 
 Return `(f(), "✓") if `f()` executes without throwing an
 exception. Otherwise, return `(ex, "×"), where `ex` is the exception

--- a/test/attemptors.jl
+++ b/test/attemptors.jl
@@ -3,9 +3,9 @@
     bad() = throw(e)
     good() = 42
 
-    @test (@test_logs MLJTest.attempt(bad)) == (e, "×")
+    @test (@test_logs MLJTest.attempt(bad, "")) == (e, "×")
     @test (@test_logs (:info, "look ×") MLJTest.attempt(bad, "look "))  == (e, "×")
-    @test (@test_logs MLJTest.attempt(good)) == (42, "✓")
+    @test (@test_logs MLJTest.attempt(good, "")) == (42, "✓")
     @test (@test_logs (:info, "look ✓") MLJTest.attempt(good, "look "))  == (42, "✓")
 end
 

--- a/test/attemptors.jl
+++ b/test/attemptors.jl
@@ -7,6 +7,7 @@
     @test (@test_logs (:info, "look ×") MLJTest.attempt(bad, "look "))  == (e, "×")
     @test (@test_logs MLJTest.attempt(good, "")) == (42, "✓")
     @test (@test_logs (:info, "look ✓") MLJTest.attempt(good, "look "))  == (42, "✓")
+    @test_throws e MLJTest.attempt(bad, ""; throw=true)
 end
 
 @testset "model_type" begin

--- a/test/test.jl
+++ b/test/test.jl
@@ -37,7 +37,14 @@ expected_summary2 = (
     y = coerce(y0, OrderedFactor);
 
     fails, summary  =
-        @test_logs MLJTest.test(classifiers, X, y; mod=@__MODULE__, verbosity=0)
+        @test_logs MLJTest.test(
+            classifiers,
+            X,
+            y;
+            mod=@__MODULE__,
+            level=3,
+            verbosity=0
+        )
     @test isempty(fails)
     @test summary[1] == expected_summary1
     @test summary[2] == expected_summary2
@@ -50,7 +57,14 @@ end
     y = coerce(y0, OrderedFactor);
 
     fails, summary  =
-        @test_logs MLJTest.test(classifiers, X, y; mod=@__MODULE__, verbosity=0)
+        @test_logs MLJTest.test(
+            classifiers,
+            X,
+            y;
+            mod=@__MODULE__,
+            level=3,
+            verbosity=0
+        )
     @test isempty(fails)
     @test summary[1] == expected_summary1
     @test summary[2] == expected_summary2
@@ -61,7 +75,14 @@ end
     fails, summary = @test_logs(
         (:error, r""),
         match_mode=:any,
-        MLJTest.test(classifiers, X, y; mod=@__MODULE__, verbosity=0)
+        MLJTest.test(
+            classifiers,
+            X,
+            y;
+            mod=@__MODULE__,
+            level=3,
+            verbosity=0
+        )
     )
 
     @test length(fails) === 2
@@ -122,7 +143,7 @@ y = coerce(y0, OrderedFactor);
         X,
         y;
         mod=@__MODULE__,
-        load_only=true,
+        level=1,
         verbosity=1);
 
     # verbosity high:
@@ -141,19 +162,20 @@ y = coerce(y0, OrderedFactor);
             X,
             y;
             mod=@__MODULE__,
+            level=3,
             verbosity=2)
     )
-end 
+end
 
-@testset "load_only=true" begin
-
+@testset "level" begin
+    # level=1:
     fails, summary  =
         @test_logs MLJTest.test(
             classifiers,
             X,
             y;
             mod=@__MODULE__,
-            load_only=true,
+            level=1,
             verbosity=0)
     @test isempty(fails)
     @test summary[1] == (
@@ -169,13 +191,43 @@ end
         ensemble_prediction = "-",
         iteration_prediction = "-",
     )
-end
 
+    # level=2:
+    fails, summary  =
+        @test_logs MLJTest.test(
+            classifiers,
+            X,
+            y;
+            mod=@__MODULE__,
+            level=2,
+            verbosity=0)
+    @test isempty(fails)
+    @test summary[1] == (
+        name = "ConstantClassifier",
+        package = "MLJModels",
+        model_type = "✓",
+        model_instance = "✓",
+        fitted_machine = "✓",
+        operations = "predict",
+        evaluation = "-",
+        tuned_pipe_evaluation = "-",
+        threshold_prediction = "-",
+        ensemble_prediction = "-",
+        iteration_prediction = "-",
+    )
+end
 
 @testset "iterative model" begin
     X, y = MLJTest.make_dummy();
     fails, summary =
-        MLJTest.test([MLJTest.DummyIterativeModel,], X, y; mod=@__MODULE__, verbosity=0)
+        MLJTest.test(
+            [MLJTest.DummyIterativeModel,],
+            X,
+            y;
+            mod=@__MODULE__,
+            level=3,
+            verbosity=0
+        )
     @test isempty(fails)
     @test summary[1] == (
         name = "DummyIterativeModel",

--- a/test/test.jl
+++ b/test/test.jl
@@ -130,6 +130,22 @@ end
         iteration_prediction = "-"
     )
 
+    # throw=true:
+    @test_logs(
+        (:error, r""), match_mode=:any,
+        @test_throws(
+            ErrorException,
+            MLJTest.test(
+                classifiers,
+                X,
+                y;
+                mod=@__MODULE__,
+                level=3,
+                throw=true,
+                verbosity=0
+            )
+        )
+    )
 end
 
 classifiers = [ConstantClassifier,]


### PR DESCRIPTION
Specifying `level` replaces `load_only` option, which makes the change breaking.
